### PR TITLE
Removes port from Dockerfile, fixing --port argument usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,11 @@ ENV APP_DIR=/usr/src/app
 
 ENV SKIP_GITIGNORE_CHECK true
 ENV NODE_ENV production
-ENV PORT 8080
 
 # Add your custom ENV vars here:
 ENV WA_POPUP true
 ENV IS_DOCKER=true
 ENV WA_DISABLE_SPINS true
-ENV WA_PORT $PORT
 ENV WA_EXECUTABLE_PATH=/usr/bin/google-chrome
 ENV WA_CLI_CONFIG=/config
 ENV CHROME_PATH=${WA_EXECUTABLE_PATH}
@@ -78,7 +76,6 @@ RUN <<eot bash
 eot
 
 RUN npm prune --production && chown -R owauser:owauser $APP_DIR
-EXPOSE $PORT
 
 # test with root later
 USER owauser

--- a/README.md
+++ b/README.md
@@ -18,8 +18,11 @@ For example:
 # Defaults
 > docker run -p 8080:8080 --init openwa/wa-automate
 
-# Custom webhook & socket mode enabled for easy integration with node-red
-> docker run -p 8080:8080 --init openwa/wa-automate -w https://webhook.site.... --socket
+# Custom webhook, port & socket mode enabled for easy integration with node-red
+> docker run -p 8080:8085 --init openwa/wa-automate -w -p 8085 https://webhook.site.... --socket
+
+# You can also use environment variables to set the port
+> docker run -e PORT=8085 -p 8080:8085 --init openwa/wa-automate -w https://webhook.site.... --socket
 ```
 
 ## Versioning


### PR DESCRIPTION
There is no reason to specify the port in the dockerfile, since the code implementation already falls back to 8080 when no port is provided.

Specifying it in the Dockerfile was causing the --port argument to be ignored, once the Dockerfile uses --force-port by default, which causes it to first check if the PORT variable is present in the environment variables.

This PR should allow people to set their own custom ports using the CLI argument.